### PR TITLE
Add turn class with basic logic and move validation

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -24,7 +24,7 @@ class Board
     
     @board_grid.each do |row|
       row.each do |cell|
-        print "."
+        print cell.state
       end
       puts "\n"
     end

--- a/lib/game_controller.rb
+++ b/lib/game_controller.rb
@@ -1,8 +1,11 @@
 require_relative 'board'
+require_relative 'turn'
+require_relative 'player'
 
 class GameController
   def start_game
     board = Board.new
+    player = Player.new
     puts "Welcome to Connect 4!!!"
     puts "Enter P to start a game, or Q to quit."
     user_input = gets.chomp.downcase
@@ -14,6 +17,18 @@ class GameController
       board.render_board
     else
       exit()
+    end
+    # currently player 1 just goes forever - we can do something like make the computer a player 2
+    # that just has random inputs, or make an entirely separate computer class, etc
+    # I'm game for whatever seems more fun!
+    # funny enough we could actually make this work with a second player if we just
+    # made their piece an O or something :)
+    turn_counter = 1
+    while turn_counter < 20
+      turn = Turn.new(player, board)
+      turn.get_move
+      board.render_board
+      turn_counter += 1
     end
   end
 end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -6,6 +6,24 @@ class Turn
     @board = board
   end
 
+  def get_move
+    move = gets.chomp.downcase
+    columns = ["a", "b", "c", "d", "e", "f", "g"]
+    while !columns.include?(move)
+      puts "Oops, that's an invalid move. Please select column A-G!"
+      move = gets.chomp.downcase
+    end
+    @board.board_grid.reverse.each do |row|
+      # require 'pry';binding.pry
+      if row[(columns.index(move))].state == "."
+        index_1 = @board.board_grid.index(row)
+        index_2 = columns.index(move)
+        set_cell(index_1, index_2)
+        break
+      end
+    end
+  end
+
   def set_cell(index_1, index_2)
     @board.board_grid[index_1][index_2].set_state(@player.piece)
   end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -10,11 +10,8 @@ class Turn
     columns = ["a", "b", "c", "d", "e", "f", "g"]
     move = validate_move(gets.chomp.downcase, columns)
     @board.board_grid.reverse.each do |row|
-      # require 'pry';binding.pry
       if row[(columns.index(move))].state == "."
-        index_1 = @board.board_grid.index(row)
-        index_2 = columns.index(move)
-        set_cell(index_1, index_2)
+        set_cell(@board.board_grid.index(row), columns.index(move))
         break
       end
     end
@@ -26,6 +23,11 @@ class Turn
       move = gets.chomp.downcase
     end
     move
+  end
+
+  def column_is_full?(move, columns)
+    column_index = columns.index(move)
+    @board.board_grid[0][column_index].state != "."
   end
 
   def set_cell(index_1, index_2)

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -1,7 +1,8 @@
 class Turn
-  attr_reader :player
-  
-  def initialize(player)
+  attr_reader :player, :board
+
+  def initialize(player, board)
     @player = player
+    @board = board
   end
 end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -1,5 +1,7 @@
 class Turn
+  attr_reader :player
+  
   def initialize(player)
-    
+    @player = player
   end
 end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -7,12 +7,8 @@ class Turn
   end
 
   def get_move
-    move = gets.chomp.downcase
     columns = ["a", "b", "c", "d", "e", "f", "g"]
-    while !columns.include?(move)
-      puts "Oops, that's an invalid move. Please select column A-G!"
-      move = gets.chomp.downcase
-    end
+    move = validate_move(gets.chomp.downcase, columns)
     @board.board_grid.reverse.each do |row|
       # require 'pry';binding.pry
       if row[(columns.index(move))].state == "."
@@ -22,6 +18,14 @@ class Turn
         break
       end
     end
+  end
+
+  def validate_move(move, valid_columns)
+    while !valid_columns.include?(move)
+      puts "Oops, that's an invalid move. Please select column A-G!"
+      move = gets.chomp.downcase
+    end
+    move
   end
 
   def set_cell(index_1, index_2)

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -1,0 +1,5 @@
+class Turn
+  def initialize(player)
+    
+  end
+end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -18,7 +18,7 @@ class Turn
   end
 
   def validate_move(move, valid_columns)
-    while !valid_columns.include?(move)
+    while !valid_columns.include?(move) || column_is_full?(move, valid_columns)
       puts "Oops, that's an invalid move. Please select column A-G!"
       move = gets.chomp.downcase
     end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -19,7 +19,7 @@ class Turn
 
   def validate_move(move, valid_columns)
     while !valid_columns.include?(move) || column_is_full?(move, valid_columns)
-      puts "Oops, that's an invalid move. Please select column A-G!"
+      puts "Oops, that's an invalid move, or a full column. Please select column A-G!"
       move = gets.chomp.downcase
     end
     move

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -5,4 +5,8 @@ class Turn
     @player = player
     @board = board
   end
+
+  def set_cell(index_1, index_2)
+    @board.board_grid[index_1][index_2].set_state(@player.piece)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require './lib/cell'
 require './lib/board'
 require './lib/game_controller'
+require './lib/turn'

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -32,8 +32,21 @@ RSpec.describe Turn do
       
       expect(board.board_grid[0][0].state).to eq(".")
       turn.set_cell(0, 0)
-      require 'pry';binding.pry
+      
       expect(board.board_grid[0][0].state).to eq("x")
+    end
+  end
+
+  describe "#validate_move" do
+    it "validates the player move against valid columns" do
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+
+      columns = ["a", "b", "c", "d", "e", "f", "g"]
+      
+      expect(turn.validate_move("a", columns)).to eq("a")
+      expect(turn.validate_move("g", columns)).to eq("g")
     end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Turn do
     end
 
     it "has a player" do
-      player = "Waiting for Player"
+      player = Player.new
       turn = Turn.new(player, "Board")
 
       expect(turn.player).to eq(player)
     end
 
     it "has a board" do
-      player = "Waiting for Player"
+      player = Player.new
       board = Board.new
       turn = Turn.new(player, board)
 
@@ -26,7 +26,7 @@ RSpec.describe Turn do
 
   describe "#set_cell" do
     it "tells a cell to change state" do
-      player = "Waiting for Player"
+      player = Player.new
       board = Board.new
       turn = Turn.new(player, board)
       

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -23,4 +23,17 @@ RSpec.describe Turn do
       expect(turn.board).to eq(board)
     end
   end
+
+  describe "#set_cell" do
+    it "tells a cell to change state" do
+      player = "Waiting for Player"
+      board = Board.new
+      turn = Turn.new(player, board)
+      
+      expect(board.board_grid[0][0].state).to eq(".")
+      board.set_cell(0, 0)
+
+      expect(board.board_grid[0][0].state).to eq("X")
+    end
+  end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Turn do
       
       expect(board.board_grid[0][0].state).to eq(".")
       turn.set_cell(0, 0)
-      
+
       expect(board.board_grid[0][0].state).to eq("x")
     end
   end
@@ -47,6 +47,20 @@ RSpec.describe Turn do
       
       expect(turn.validate_move("a", columns)).to eq("a")
       expect(turn.validate_move("g", columns)).to eq("g")
+    end
+  end
+
+  describe "#column_is_full?" do
+    it "returns true/false if a column is currently full (top row has a piece)" do
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+
+      columns = ["a", "b", "c", "d", "e", "f", "g"]
+      board.board_grid[0][0].set_state("x")
+
+      expect(turn.column_is_full?("a", columns)).to be true
+      expect(turn.column_is_full?("b", columns)).to be false
     end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Turn do
       turn = Turn.new(player, board)
       
       expect(board.board_grid[0][0].state).to eq(".")
-      board.set_cell(0, 0)
-
-      expect(board.board_grid[0][0].state).to eq("X")
+      turn.set_cell(0, 0)
+      require 'pry';binding.pry
+      expect(board.board_grid[0][0].state).to eq("x")
     end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -3,16 +3,24 @@ require 'spec_helper'
 RSpec.describe Turn do
   describe "#initialize" do
     it "exists" do
-      turn = Turn.new("player")
+      turn = Turn.new("player", "Board")
 
       expect(turn).to be_a Turn
     end
 
     it "has a player" do
       player = "Waiting for Player"
-      turn = Turn.new(player)
+      turn = Turn.new(player, "Board")
 
       expect(turn.player).to eq(player)
+    end
+
+    it "has a board" do
+      player = "Waiting for Player"
+      board = Board.new
+      turn = Turn.new(player, board)
+
+      expect(turn.board).to eq(board)
     end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -38,12 +38,25 @@ RSpec.describe Turn do
   end
 
   describe "#validate_move" do
+    # can't really test sad paths on these as they would repeat user inputs
     it "validates the player move against valid columns" do
       player = Player.new
       board = Board.new
       turn = Turn.new(player, board)
 
       columns = ["a", "b", "c", "d", "e", "f", "g"]
+      
+      expect(turn.validate_move("a", columns)).to eq("a")
+      expect(turn.validate_move("g", columns)).to eq("g")
+    end
+
+    it "only validates if the column is not full" do
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+
+      columns = ["a", "b", "c", "d", "e", "f", "g"]
+      board.board_grid[0][1].set_state('x')
       
       expect(turn.validate_move("a", columns)).to eq("a")
       expect(turn.validate_move("g", columns)).to eq("g")

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Turn do
+  describe "#initialize" do
+    it "exists" do
+      turn = Turn.new("player")
+
+      expect(turn).to be_a Turn
+    end
+  end
+end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -7,5 +7,12 @@ RSpec.describe Turn do
 
       expect(turn).to be_a Turn
     end
+
+    it "has a player" do
+      player = "Waiting for Player"
+      turn = Turn.new(player)
+
+      expect(turn.player).to eq(player)
+    end
   end
 end


### PR DESCRIPTION
This PR adds the Turn class (very close to what we planned out - yay!). The idea of Turn is to receive the current player and current state of the board, then ask the player (later computer) for input and update the board to reflect that move. There are two main methods and a few helpers.

MAINS:
- #get_move: asks for user input, and calls on its helper (validate_move) to ensure the move is fair and valid. Once validity is established, set_cell is called to change the board state.
- #set_cell: takes in two integers as arguments, and changes the cell state at the corresponding position on the board.

HELPERS:
- #validate_move: takes a move and an array of valid columns as arguments. The move is compared against the valid columns to ensure the column exists. If not, the user is reminded of valid columns and asked for a new input. Additionally validates via a helper method #column_is_full?
- #column_is_full?: takes a move and an array of columns as arguments. The column corresponding to the move is checked for fullness on the top row. If full, returns true. If empty, returns false.

TESTING: Any method that takes a user input is NOT tested. In this case, only #get_move is lacking a test.

ADDITIONAL NOTES:
This PR also does a small update to the start_game method on GameController to allow 20 consecutive turns for the one player that currently exists. Mostly just for testing purposes!