### PR TITLE
Refactor turn

### DIFF
--- a/lib/game_controller.rb
+++ b/lib/game_controller.rb
@@ -25,15 +25,18 @@ class GameController
     # I'm game for whatever seems more fun!
     # funny enough we could actually make this work with a second player if we just
     # made their piece an O or something :)
+
     turn_counter = 1
     while !board.board_is_full?
 
       if turn_counter % 2 == 0
         turn = Turn.new(computer, board)
-        turn.get_computer_move
+        turn.get_move
+        turn.set_cell
       else
         turn = Turn.new(player, board)
         turn.get_move
+        turn.set_cell
       end
       board.render_board
       turn_counter += 1

--- a/lib/game_controller.rb
+++ b/lib/game_controller.rb
@@ -32,10 +32,12 @@ class GameController
         turn = Turn.new(computer, board)
         turn.get_move
         turn.set_cell
+        turn.check_win_conditions
       else
         turn = Turn.new(player, board)
         turn.get_move
         turn.set_cell
+        turn.check_win_conditions
       end
       board.render_board
       turn_counter += 1

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -51,58 +51,52 @@ class Turn
   end
   
   def set_cell
-    find_lowest_cell_in_column.set_state(@player.piece)
+    index_array = find_lowest_cell_in_column
+    @board.board_grid[index_array[0]][index_array[1]].set_state(@player.piece)
+    # check_horizontal_win(index_array[0], index_array[1])
+    # check_vertical_win(index_array[0], index_array[1])
   end
   
   def find_lowest_cell_in_column
-    lowest_cell = nil
+    index_1 = nil
+    index_2 = nil
     @board.board_grid.reverse.each do |row|
       if row[(@columns.index(@move))].state == "."
-        lowest_cell = @board.board_grid[@board.board_grid.index(row)][@columns.index(@move)]
+        index_1 = @board.board_grid.index(row)
+        index_2 = @columns.index(@move)
         break
       end
     end
-    lowest_cell
+    [index_1, index_2]
   end
 
-  def check_horizontal_win(index_1, index_2)
-    current_pos = @board.board_grid[index_1][index_2]
-    current_index = 0 + index_2
-    pieces_in_a_row = 1
-    until current_index < 0 || (current_pos.state != @player.piece)
-      pieces_in_a_row += 1 if current_index < index_2
-      current_index -= 1
-      current_pos = @board.board_grid[index_1][current_index]
-    end
-    current_pos = @board.board_grid[index_1][index_2]
-    current_index = 0 + index_2
-    until current_index > 6 || (current_pos.state != @player.piece)
-      # require 'pry';binding.pry
-      pieces_in_a_row += 1 if current_index > index_2
-      current_index += 1
-      current_pos = @board.board_grid[index_1][current_index]
-      # require 'pry';binding.pry
-    end
-    @player.winner = true if pieces_in_a_row >= 4
+  def check_win_conditions
+    check_horizontal_win
+    check_vertical_win
   end
 
-  def check_vertical_win(index_1, index_2)
-    current_pos = @board.board_grid[index_1][index_2]
-    current_index = 0 + index_1
-    pieces_in_a_row = 1
-    until current_index < 0 || (current_pos.state != @player.piece)
-      pieces_in_a_row += 1 if current_index < index_1
-      current_index -= 1
-      current_pos = @board.board_grid[current_index][index_2]
+  def get_board_as_states
+    @board.board_grid.map do |row|
+      row.map do |cell|
+        cell.state
+      end
     end
-    current_pos = board.board_grid[index_1][index_2]
-    current_index = 0 + index_1
-    until current_index > 5 || (current_pos.state != @player.piece)
-      pieces_in_a_row += 1 if current_index > index_1
-      current_index += 1
-      current_pos = @board.board_grid[current_index][index_2] if current_index < 6
-      # require 'pry';binding.pry
+  end
+  
+  def check_horizontal_win
+    winning_string = ""
+    4.times { winning_string += "#{@player.piece}" }
+    board_as_states = get_board_as_states
+    board_as_states.each do |row|
+      @player.winner = true if row.join.include?(winning_string)
     end
-    @player.winner = true if pieces_in_a_row >= 4
+  end
+
+  def check_vertical_win
+    winning_string = ""
+    4.times { winning_string += "#{@player.piece}" }
+    board_as_states = get_board_as_states
+    column_as_array = board_as_states.map { |row| row[@columns.index(@move)] }
+    @player.winner = true if column_as_array.join.include?(winning_string)
   end
 end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -1,56 +1,67 @@
 class Turn
-  attr_reader :player, :board, :columns
+  attr_reader :player,
+              :board,
+              :columns
+              
+  attr_accessor :move
 
   def initialize(player, board)
     @player = player
     @board = board
     @columns = ["a", "b", "c", "d", "e", "f", "g"]
+    @move = nil
   end
 
   def get_move
-    move = validate_move(gets.chomp.downcase, @columns)
-    find_lowest_cell_in_column(move, @columns)
+    if @player.instance_of?(Player)
+      move = validate_player_move(gets.chomp.downcase)
+    else
+      move = get_computer_move
+    end
+    @move = move
   end
   
-  def validate_move(move, valid_columns)
-    while !valid_columns.include?(move) || column_is_full?(move, valid_columns)
+  def validate_player_move(move)
+    while !@columns.include?(move) || column_is_full?(move)
       puts "Oops, that's an invalid move, or a full column. Please select column A-G!"
       move = gets.chomp.downcase
     end
     move
   end
+
+  def column_is_full?(move)
+    column_index = @columns.index(move)
+    @board.board_grid[0][column_index].state != "."
+  end
   
   def get_computer_move
     computer_move = @columns.sample
-    while validate_cpu_move(computer_move, columns) == "invalid"
+    while validate_cpu_move(computer_move) == "invalid"
       computer_move = @columns.sample
     end
-    find_lowest_cell_in_column(computer_move, @columns)
+    computer_move
   end
 
-  def validate_cpu_move(move, valid_columns)
-    if column_is_full?(move, valid_columns)
+  def validate_cpu_move(move)
+    if column_is_full?(move)
       return "invalid"
     else 
       move
     end
   end
-
-  def find_lowest_cell_in_column(move, valid_columns)
+  
+  def set_cell
+    find_lowest_cell_in_column.set_state(@player.piece)
+  end
+  
+  def find_lowest_cell_in_column
+    lowest_cell = nil
     @board.board_grid.reverse.each do |row|
-      if row[(valid_columns.index(move))].state == "."
-        set_cell(@board.board_grid.index(row), valid_columns.index(move))
+      if row[(@columns.index(@move))].state == "."
+        lowest_cell = @board.board_grid[@board.board_grid.index(row)][@columns.index(@move)]
         break
       end
     end
-  end
-
-  def column_is_full?(move, columns)
-    column_index = @columns.index(move)
-    @board.board_grid[0][column_index].state != "."
-  end
-
-  def set_cell(index_1, index_2)
-    @board.board_grid[index_1][index_2].set_state(@player.piece)
+    lowest_cell
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -108,12 +108,12 @@ RSpec.describe Turn do
       turn = Turn.new(player, board)
 
       turn.move = "a"
-      expect(turn.find_lowest_cell_in_column).to eq(board.board_grid[5][0])
+      expect(turn.find_lowest_cell_in_column).to eq([5, 0])
 
       turn.move = "b"
       board.board_grid[5][1].set_state("x")
       
-      expect(turn.find_lowest_cell_in_column).to eq(board.board_grid[4][1])
+      expect(turn.find_lowest_cell_in_column).to eq([4, 1])
     end
   end
 
@@ -123,14 +123,14 @@ RSpec.describe Turn do
       board = Board.new
       turn = Turn.new(player, board)
 
-      turn.check_horizontal_win(5, 2)
+      turn.check_horizontal_win
       expect(player.winner).to be false
 
       board.board_grid[5][0].set_state("x")
       board.board_grid[5][1].set_state("x")
       board.board_grid[5][2].set_state("x")
       board.board_grid[5][3].set_state("x")
-      turn.check_horizontal_win(5, 2)
+      turn.check_horizontal_win
 
       expect(player.winner).to be true
     end
@@ -141,17 +141,51 @@ RSpec.describe Turn do
       player = Player.new
       board = Board.new
       turn = Turn.new(player, board)
+      turn.move = "b"
 
-      turn.check_vertical_win(1, 1)
+      turn.check_vertical_win
       expect(player.winner).to be false
 
       board.board_grid[2][1].set_state("x")
       board.board_grid[3][1].set_state("x")
       board.board_grid[4][1].set_state("x")
       board.board_grid[5][1].set_state("x")
-      # require 'pry';binding.pry
-      turn.check_vertical_win(2, 1)
+      turn.check_vertical_win
     
+      expect(player.winner).to be true
+    end
+  end
+
+  describe "#check_win_conditions" do
+    it "checks for horizontal wins" do
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+      turn.move = "b"
+
+      board.board_grid[4][0].set_state("x")
+      board.board_grid[4][1].set_state("x")
+      board.board_grid[4][2].set_state("x")
+      board.board_grid[4][3].set_state("x")
+
+      turn.check_win_conditions
+
+      expect(player.winner).to be true
+    end
+
+    it "checks for vertical wins" do
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+      turn.move = "c"
+
+      board.board_grid[2][2].set_state("x")
+      board.board_grid[3][2].set_state("x")
+      board.board_grid[4][2].set_state("x")
+      board.board_grid[5][2].set_state("x")
+
+      turn.check_win_conditions
+
       expect(player.winner).to be true
     end
   end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -189,4 +189,25 @@ RSpec.describe Turn do
       expect(player.winner).to be true
     end
   end
+
+  describe "#board_as_state" do
+    it "get the current board with all cell states" do
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+
+      expect(turn.get_board_as_states).to all be_an Array
+      expect(turn.get_board_as_states[0]).to all eq(".")
+    end
+
+    it "accounts for cells not in their default state" do
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+
+      board.board_grid[2][2].set_state("x")
+
+      expect(turn.get_board_as_states[2]).to include('x')
+    end
+  end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -38,24 +38,23 @@ RSpec.describe Turn do
       board = Board.new
       turn = Turn.new(player, board)
       
-      expect(board.board_grid[0][0].state).to eq(".")
-      turn.set_cell(0, 0)
+      turn.move = "a"
+      expect(board.board_grid[5][0].state).to eq(".")
+      turn.set_cell
 
-      expect(board.board_grid[0][0].state).to eq("x")
+      expect(board.board_grid[5][0].state).to eq("x")
     end
   end
 
-  describe "#validate_move" do
+  describe "#validate_player_move" do
     # can't really test sad paths on these as they would repeat user inputs
     it "validates the player move against valid columns" do
       player = Player.new
       board = Board.new
       turn = Turn.new(player, board)
-
-      columns = ["a", "b", "c", "d", "e", "f", "g"]
       
-      expect(turn.validate_move("a", columns)).to eq("a")
-      expect(turn.validate_move("g", columns)).to eq("g")
+      expect(turn.validate_player_move("a")).to eq("a")
+      expect(turn.validate_player_move("g")).to eq("g")
     end
 
     it "only validates if the column is not full" do
@@ -63,11 +62,10 @@ RSpec.describe Turn do
       board = Board.new
       turn = Turn.new(player, board)
 
-      columns = ["a", "b", "c", "d", "e", "f", "g"]
       board.board_grid[0][1].set_state('x')
       
-      expect(turn.validate_move("a", columns)).to eq("a")
-      expect(turn.validate_move("g", columns)).to eq("g")
+      expect(turn.validate_player_move("a")).to eq("a")
+      expect(turn.validate_player_move("g")).to eq("g")
     end
   end
 
@@ -77,33 +75,29 @@ RSpec.describe Turn do
       board = Board.new
       turn = Turn.new(player, board)
 
-      columns = ["a", "b", "c", "d", "e", "f", "g"]
       board.board_grid[0][0].set_state("x")
       
-      expect(turn.column_is_full?("a", columns)).to be true
-      expect(turn.column_is_full?("b", columns)).to be false
+      expect(turn.column_is_full?("a")).to be true
+      expect(turn.column_is_full?("b")).to be false
     end
   end
   
-  describe "#validate_computer move" do 
-    it "validates if computers random move" do 
+  describe "#validate_computer_move" do 
+    it "validates the computers random move" do 
       computer = Computer.new
       board = Board.new
       turn = Turn.new(computer, board)
-      columns = ["a", "b", "c", "d", "e", "f", "g"]
       
-      
-      expect(turn.validate_cpu_move("b", columns)).to eq("b")
+      expect(turn.validate_cpu_move("b")).to eq("b")
     end
     
     it "returns invalid if the column is full" do 
       computer = Computer.new
       board = Board.new
       turn = Turn.new(computer, board)
-      columns = ["a", "b", "c", "d", "e", "f", "g"]
       
       board.board_grid[0][0].set_state("x")
-      expect(turn.validate_cpu_move("a", columns)).to eq("invalid")
+      expect(turn.validate_cpu_move("a")).to eq("invalid")
     end
   end 
   
@@ -112,12 +106,14 @@ RSpec.describe Turn do
       player = Player.new
       board = Board.new
       turn = Turn.new(player, board)
-      move = "a"
+
+      turn.move = "a"
+      expect(turn.find_lowest_cell_in_column).to eq(board.board_grid[5][0])
+
+      turn.move = "b"
+      board.board_grid[5][1].set_state("x")
       
-      # require 'pry';binding.pry
-      turn.find_lowest_cell_in_column(move, turn.columns)
-      expect(board.board_grid[4][0].state).to eq(".")
-      expect(board.board_grid[5][0].state).to eq("x")
+      expect(turn.find_lowest_cell_in_column).to eq(board.board_grid[4][1])
     end
   end
 end


### PR DESCRIPTION
Big PR here. We did a bulk of this on a call, but the general idea is adding @move as an instance variable on Turn. The big issue we found was our methods were chained together and NOT following SRP at all. By moving @move out of the methods, we were able to split things out to be a bit more individually purposed, and actually follow their namesakes.

The big inclusion here is just adding new tests for how the win conditions got split out.