### PR TITLE
Win check diagonal aa

### DIFF
--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -73,6 +73,7 @@ class Turn
   def check_win_conditions
     check_horizontal_win
     check_vertical_win
+    check_diagonal_win
   end
 
   def get_board_as_states
@@ -98,5 +99,31 @@ class Turn
     board_as_states = get_board_as_states
     column_as_array = board_as_states.map { |row| row[@columns.index(@move)] }
     @player.winner = true if column_as_array.join.include?(winning_string)
+  end
+
+  #range is acting as way to create index positions to check index positions on our board
+  def diag_offset_columns 
+    board = get_board_as_states
+    (1..3).map do |outer_int|
+      (outer_int..(board[0].size - 1)).collect {|inner_int| board[inner_int - outer_int][inner_int]}
+    end
+  end
+
+  def diag_offset_rows
+    board = get_board_as_states
+    (0..2).map do |outer_int|
+      (outer_int..(board.size - 1)).collect {|inner_int| board[inner_int][inner_int - outer_int]}
+    end
+  end
+
+  def check_diagonal_win
+    winning_string = ""
+    4.times { winning_string += "#{@player.piece}" }
+    diag_offset_columns.each do |array|
+      @player.winner = true if array.join.include?(winning_string)
+    end
+    diag_offset_rows.each do |array|
+      @player.winner = true if array.join.include?(winning_string)
+    end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -161,20 +161,41 @@ RSpec.describe Turn do
       player = Player.new
       board = Board.new
       turn = Turn.new(player, board)
-      turn.move = "c" #may not need this
       
       turn.check_diagonal_win
-
+      
       expect(player.winner).to be false
-
+      
       board.board_grid[0][0].set_state("x")
       board.board_grid[1][1].set_state("x")
       board.board_grid[2][2].set_state("x")
       board.board_grid[3][3].set_state("x")
-
+      
       turn.check_diagonal_win
-
+      
       expect(player.winner).to be true
+    end
+  end
+  
+  describe "#diag_offset_columns" do 
+    it "returns an array of all diagonals from columns 1 - 3" do 
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+    
+      expect(turn.diag_offset_columns.size).to eq(3)
+      expect(turn.diag_offset_columns).to all be_a Array 
+    end
+  end
+
+  describe "#diag_offset_rows" do 
+    it "returns an array of all diagonals from rows 0 - 2" do 
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+    
+      expect(turn.diag_offset_rows.size).to eq(3)
+      expect(turn.diag_offset_rows).to all be_a Array 
     end
   end
 
@@ -230,6 +251,7 @@ RSpec.describe Turn do
       board.board_grid[2][2].set_state("x")
 
       expect(turn.get_board_as_states[2]).to include('x')
+      # require 'pry';binxding.pry
     end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -156,6 +156,28 @@ RSpec.describe Turn do
     end
   end
 
+  describe "#check_diagonal_win" do 
+    it "checks for horizontal wins" do 
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+      turn.move = "c" #may not need this
+      
+      turn.check_diagonal_win
+
+      expect(player.winner).to be false
+
+      board.board_grid[0][0].set_state("x")
+      board.board_grid[1][1].set_state("x")
+      board.board_grid[2][2].set_state("x")
+      board.board_grid[3][3].set_state("x")
+
+      turn.check_diagonal_win
+
+      expect(player.winner).to be true
+    end
+  end
+
   describe "#check_win_conditions" do
     it "checks for horizontal wins" do
       player = Player.new


### PR DESCRIPTION
Wow, what journey. 

This PR includes a couple helper methods that contribute to check_diagonal win:

1. get_diag_rows - gets all potential diagonal from row 0-2 - this returns an array of arrays that include the cell states for the diagonals starting at those positions and moving down and right
2. get_diag_columns - gets all potential diagonals from colums 1-3 and returns an array of arrays that include the cell states for the diagonals starting  at those positions and also moving down and right 

main method: 

1. check_diagonal win - this incorporates the above two methods and check within each array (nested in an array) if the "winning_string" which we used in previous method is included in those arrays.


Tests: 
1. tests for the helper methods simply check if the size of the array provided gives us the expected size of the array (which we know this by knowing the size of the board). The tests also simply check if each item within the array is an array. 
2. Test for check_diagonal_win only account for the conditions of the current helper methods. In the next step we will flip our board and recycle the helper methods to check for diagonals going the other way. 

considerations: 
1. for the helper methods tests - not sure how to test for the exact contents of the arrays, we are assuming because we know the size of the board. 
2. do we want to refactor our winning_string to the player/computer classes to  increase DRYness of the turn class. 
