### PR TITLE
Add sw ne diagonals to diag win conditions

### DIFF
--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -53,8 +53,6 @@ class Turn
   def set_cell
     index_array = find_lowest_cell_in_column
     @board.board_grid[index_array[0]][index_array[1]].set_state(@player.piece)
-    # check_horizontal_win(index_array[0], index_array[1])
-    # check_vertical_win(index_array[0], index_array[1])
   end
   
   def find_lowest_cell_in_column

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -118,10 +118,17 @@ class Turn
     winning_string = ""
     4.times { winning_string += "#{@player.piece}" }
     board_states = get_board_as_states
+    board_rotated = board_states.transpose.reverse
     diag_offset_columns(board_states, (1..3)).each do |array|
       @player.winner = true if array.join.include?(winning_string)
     end
     diag_offset_rows(board_states, (0..2)).each do |array|
+      @player.winner = true if array.join.include?(winning_string)
+    end
+    diag_offset_columns(board_rotated, (0..2)).each do |array|
+      @player.winner = true if array.join.include?(winning_string)
+    end
+    diag_offset_rows(board_rotated, (1..3)).each do |array|
       @player.winner = true if array.join.include?(winning_string)
     end
   end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -102,16 +102,14 @@ class Turn
   end
 
   #range is acting as way to create index positions to check index positions on our board
-  def diag_offset_columns 
-    board = get_board_as_states
-    (1..3).map do |outer_int|
+  def diag_offset_columns(board, range)
+    range.map do |outer_int|
       (outer_int..(board[0].size - 1)).collect {|inner_int| board[inner_int - outer_int][inner_int]}
     end
   end
 
-  def diag_offset_rows
-    board = get_board_as_states
-    (0..2).map do |outer_int|
+  def diag_offset_rows(board, range)
+    range.map do |outer_int|
       (outer_int..(board.size - 1)).collect {|inner_int| board[inner_int][inner_int - outer_int]}
     end
   end
@@ -119,10 +117,11 @@ class Turn
   def check_diagonal_win
     winning_string = ""
     4.times { winning_string += "#{@player.piece}" }
-    diag_offset_columns.each do |array|
+    board_states = get_board_as_states
+    diag_offset_columns(board_states, (1..3)).each do |array|
       @player.winner = true if array.join.include?(winning_string)
     end
-    diag_offset_rows.each do |array|
+    diag_offset_rows(board_states, (0..2)).each do |array|
       @player.winner = true if array.join.include?(winning_string)
     end
   end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Turn do
   end
 
   describe "#check_diagonal_win" do 
-    it "checks for horizontal wins" do 
+    it "checks for diagonal wins NW to SE - 4 in a row on a diag" do 
       player = Player.new
       board = Board.new
       turn = Turn.new(player, board)
@@ -171,6 +171,25 @@ RSpec.describe Turn do
       board.board_grid[2][2].set_state("x")
       board.board_grid[3][3].set_state("x")
       
+      turn.check_diagonal_win
+      
+      expect(player.winner).to be true
+    end
+
+    it "checks for diagonal wins SW to NE" do
+      player = Player.new
+      board = Board.new
+      turn = Turn.new(player, board)
+      
+      turn.check_diagonal_win
+      
+      expect(player.winner).to be false
+
+      board.board_grid[5][0].set_state("x")
+      board.board_grid[4][1].set_state("x")
+      board.board_grid[3][2].set_state("x")
+      board.board_grid[2][3].set_state("x")
+
       turn.check_diagonal_win
       
       expect(player.winner).to be true

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -274,7 +274,6 @@ RSpec.describe Turn do
       board.board_grid[2][2].set_state("x")
 
       expect(turn.get_board_as_states[2]).to include('x')
-      # require 'pry';binxding.pry
     end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -178,24 +178,28 @@ RSpec.describe Turn do
   end
   
   describe "#diag_offset_columns" do 
-    it "returns an array of all diagonals from columns 1 - 3" do 
+    it "returns an array of all diagonals offset (by column) by a given range" do 
       player = Player.new
       board = Board.new
       turn = Turn.new(player, board)
+
+      board_states = turn.get_board_as_states
     
-      expect(turn.diag_offset_columns.size).to eq(3)
-      expect(turn.diag_offset_columns).to all be_a Array 
+      expect(turn.diag_offset_columns(board_states, (1..3)).size).to eq(3)
+      expect(turn.diag_offset_columns(board_states, (1..3))).to all be_a Array 
     end
   end
 
   describe "#diag_offset_rows" do 
-    it "returns an array of all diagonals from rows 0 - 2" do 
+    it "returns an array of all diagonals offset (by row) by a given range" do 
       player = Player.new
       board = Board.new
       turn = Turn.new(player, board)
+
+      board_states = turn.get_board_as_states
     
-      expect(turn.diag_offset_rows.size).to eq(3)
-      expect(turn.diag_offset_rows).to all be_a Array 
+      expect(turn.diag_offset_rows(board_states, (0..2)).size).to eq(3)
+      expect(turn.diag_offset_rows(board_states, (0..2))).to all be_a Array 
     end
   end
 


### PR DESCRIPTION
Following up on your PR here, we needed to expand our diagonal methods to account for antediagonals. For the purpose of clarity I'll refer to the sides of our grids as north, east, south and west... i.e. [0][0] = nw corner.

The methods, as they were, checked for diagonal lines starting in the NW and moving to the SE corners. That's only half the diagonals we need to account for, so this PR expands our diagonals to handle SW to NE corners. We did a bit of research (and you rotated your paper around) and we came to the consensus that the SW -> NE diagonals can just be rotated 90 degrees and then look like NW -> SE corners, thus letting us use our existing methods.

So the modifications made here:

- diag_offset helper methods now take arguments of the current board state, and the range to offset by
- check_diagonal_wins now passes the current board to each offset helper, and then rotates the board 90 degrees and sends it to the helpers again
- added a test to make sure SW -> NE diagonals are picked up by our methods properly

And with this PR... OUR GAME WORKS!!!